### PR TITLE
Add last updated timestamp and version display in footer

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,4 +1,4 @@
-name: CI
+name: "PR: Validate & Preview"
 
 on:
   pull_request:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -250,6 +250,9 @@ jobs:
           echo "build_time=${BUILD_TIME}" >> $GITHUB_OUTPUT
         env:
           CI: true
+          # Use PR head commit, not the merge commit that GitHub creates for PR checks
+          GATSBY_BUILD_TIME: ${{ github.event.pull_request.updated_at }}
+          GATSBY_COMMIT_SHA: ${{ github.event.pull_request.head.sha }}
 
       - name: Generate build stats and compare
         id: stats

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -238,6 +238,15 @@ jobs:
 
           echo "::remove-matcher owner=tsc::"
 
+      - name: Get PR head commit timestamp
+        id: pr-commit
+        run: |
+          # Get the timestamp of the actual PR head commit (not the merge commit)
+          COMMIT_TIMESTAMP=$(git log -1 --format=%cI ${{ github.event.pull_request.head.sha }})
+          echo "timestamp=${COMMIT_TIMESTAMP}" >> $GITHUB_OUTPUT
+          echo "PR head commit: ${{ github.event.pull_request.head.sha }}"
+          echo "Commit timestamp: ${COMMIT_TIMESTAMP}"
+
       - name: Build PR branch
         id: build
         run: |
@@ -250,8 +259,8 @@ jobs:
           echo "build_time=${BUILD_TIME}" >> $GITHUB_OUTPUT
         env:
           CI: true
-          # Use PR head commit, not the merge commit that GitHub creates for PR checks
-          GATSBY_BUILD_TIME: ${{ github.event.pull_request.updated_at }}
+          # Use PR head commit info, not the merge commit that GitHub creates for PR checks
+          GATSBY_BUILD_TIME: ${{ steps.pr-commit.outputs.timestamp }}
           GATSBY_COMMIT_SHA: ${{ github.event.pull_request.head.sha }}
 
       - name: Generate build stats and compare

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -56,7 +56,6 @@ jobs:
           CI: true
           GATSBY_BUILD_TIME: ${{ github.event.head_commit.timestamp }}
           GATSBY_COMMIT_SHA: ${{ github.sha }}
-          GATSBY_COMMIT_MESSAGE: ${{ github.event.head_commit.message }}
 
       - name: Deploy to GitHub Pages
         uses: peaceiris/actions-gh-pages@v4

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -54,6 +54,9 @@ jobs:
         run: npm run build
         env:
           CI: true
+          GATSBY_BUILD_TIME: ${{ github.event.head_commit.timestamp }}
+          GATSBY_COMMIT_SHA: ${{ github.sha }}
+          GATSBY_COMMIT_MESSAGE: ${{ github.event.head_commit.message }}
 
       - name: Deploy to GitHub Pages
         uses: peaceiris/actions-gh-pages@v4

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -1,4 +1,4 @@
-name: Deploy to GitHub Pages
+name: "Deploy: Production"
 
 on:
   push:

--- a/.github/workflows/preview-cleanup.yml
+++ b/.github/workflows/preview-cleanup.yml
@@ -1,4 +1,4 @@
-name: Cleanup Preview
+name: "PR: Cleanup Preview"
 
 on:
   pull_request:

--- a/gatsby-config.ts
+++ b/gatsby-config.ts
@@ -5,10 +5,15 @@ require("dotenv").config({
 	path: `.env`
 })
 
-// Get git info for local development fallback
+/**
+ * Get git info for local development fallback.
+ * In CI (GitHub Actions), these values come from environment variables.
+ * Locally, we fall back to git commands, or "dev" if git is unavailable.
+ */
 const getGitInfo = () => {
 	try {
-		const sha = execSync("git rev-parse --short HEAD").toString().trim()
+		// Use --short=7 for consistent 7-character SHA
+		const sha = execSync("git rev-parse --short=7 HEAD").toString().trim()
 		const timestamp = execSync("git log -1 --format=%cI").toString().trim()
 		return { sha, timestamp }
 	} catch {
@@ -24,9 +29,10 @@ const config: GatsbyConfig = {
 		title  : `Andrei Cozma's Personal Portfolio`,
 		image: `/avatar_home.jpg`,
 		description: `This is my personal portfolio website, showcasing my education, work experiences, projects, achievements, licenses, and certifications, and much more!`,
+		// Build metadata: prefer CI env vars, fall back to git info for local dev
 		buildTime: process.env.GATSBY_BUILD_TIME || gitInfo.timestamp,
-		commitSha: (process.env.GATSBY_COMMIT_SHA || gitInfo.sha).substring(0, 7),
-		version: require("./package.json").version,
+		// Only truncate the full SHA from CI; gitInfo.sha is already short
+		commitSha: process.env.GATSBY_COMMIT_SHA?.substring(0, 7) || gitInfo.sha,
 	}, // More easily incorporate content into your pages through automatic TypeScript type generation and better GraphQL IntelliSense.
 	// If you use VSCode you can also use the GraphQL plugin
 	// Learn more at: https://gatsby.dev/graphql-typegen

--- a/gatsby-config.ts
+++ b/gatsby-config.ts
@@ -1,15 +1,32 @@
 import type { GatsbyConfig } from "gatsby"
+import { execSync } from "child_process"
 
 require("dotenv").config({
 	path: `.env`
 })
+
+// Get git info for local development fallback
+const getGitInfo = () => {
+	try {
+		const sha = execSync("git rev-parse --short HEAD").toString().trim()
+		const timestamp = execSync("git log -1 --format=%cI").toString().trim()
+		return { sha, timestamp }
+	} catch {
+		return { sha: "dev", timestamp: new Date().toISOString() }
+	}
+}
+
+const gitInfo = getGitInfo()
 
 const config: GatsbyConfig = {
 	siteMetadata: {
 		siteUrl: `https://www.andreicozma.com`,
 		title  : `Andrei Cozma's Personal Portfolio`,
 		image: `/avatar_home.jpg`,
-		description: `This is my personal portfolio website, showcasing my education, work experiences, projects, achievements, licenses, and certifications, and much more!`
+		description: `This is my personal portfolio website, showcasing my education, work experiences, projects, achievements, licenses, and certifications, and much more!`,
+		buildTime: process.env.GATSBY_BUILD_TIME || gitInfo.timestamp,
+		commitSha: (process.env.GATSBY_COMMIT_SHA || gitInfo.sha).substring(0, 7),
+		version: require("./package.json").version,
 	}, // More easily incorporate content into your pages through automatic TypeScript type generation and better GraphQL IntelliSense.
 	// If you use VSCode you can also use the GraphQL plugin
 	// Learn more at: https://gatsby.dev/graphql-typegen

--- a/src/Utils.tsx
+++ b/src/Utils.tsx
@@ -15,12 +15,28 @@ export const useSiteMetadata = () => {
           image
           title
           description
+          buildTime
+          commitSha
+          version
         }
       }
     }
   `)
 
 	return data.site.siteMetadata
+}
+
+export const formatBuildDate = (isoString: string): string => {
+	try {
+		const date = new Date(isoString)
+		return date.toLocaleDateString("en-US", {
+			year: "numeric",
+			month: "short",
+			day: "numeric"
+		})
+	} catch {
+		return "Unknown"
+	}
 }
 
 export const usePage = (title: string) => {

--- a/src/Utils.tsx
+++ b/src/Utils.tsx
@@ -17,7 +17,6 @@ export const useSiteMetadata = () => {
           description
           buildTime
           commitSha
-          version
         }
       }
     }
@@ -26,17 +25,22 @@ export const useSiteMetadata = () => {
 	return data.site.siteMetadata
 }
 
+/**
+ * Formats an ISO date string to a human-readable format (e.g., "Dec 21, 2025").
+ * Returns "Unknown" if the date string is invalid.
+ * Note: new Date() doesn't throw for invalid strings - it returns Invalid Date,
+ * so we check validity using isNaN(date.getTime()).
+ */
 export const formatBuildDate = (isoString: string): string => {
-	try {
-		const date = new Date(isoString)
-		return date.toLocaleDateString("en-US", {
-			year: "numeric",
-			month: "short",
-			day: "numeric"
-		})
-	} catch {
+	const date = new Date(isoString)
+	if (isNaN(date.getTime())) {
 		return "Unknown"
 	}
+	return date.toLocaleDateString("en-US", {
+		year: "numeric",
+		month: "short",
+		day: "numeric"
+	})
 }
 
 export const usePage = (title: string) => {

--- a/src/components/PageElements/Page.tsx
+++ b/src/components/PageElements/Page.tsx
@@ -22,7 +22,7 @@ interface PageProps {
 }
 
 const PageFooter = () => {
-	const { buildTime, commitSha, version } = useSiteMetadata()
+	const { buildTime, commitSha } = useSiteMetadata()
 	const formattedDate = formatBuildDate(buildTime)
 
 	return (
@@ -31,7 +31,8 @@ const PageFooter = () => {
 			sx={{
 				textAlign: "center",
 				py: 2,
-				mt: 4,
+				mt: "auto",
+				pt: 4,
 				opacity: 0.6,
 			}}
 		>
@@ -43,7 +44,7 @@ const PageFooter = () => {
 						"&:hover": { opacity: 0.8 }
 					}}
 				>
-					Last updated {formattedDate} · v{version}
+					Last updated {formattedDate}
 				</Typography>
 			</Tooltip>
 		</Box>
@@ -88,27 +89,30 @@ const Page = (props: PageProps) => {
 		<ResponsiveTopBar page={props.pageProps}/>
 
 		<Provider store={store}>
-			<Container component={Stack} spacing={2}
-					   sx={{
-						   paddingBottom: 3,
-						   opacity      : 0.99,
-						   marginTop    : "75px"
-					   }}>
-				{props.pageProps.sections && <PageBreadcrumbs page={props.pageProps}/>}
-				{props.pageProps.notes && <SlideNotes notesArray={props.pageProps.notes}/>}
+			<Box sx={{ display: "flex", flexDirection: "column", minHeight: "100vh" }}>
+				<Container component={Stack} spacing={2}
+						   sx={{
+							   paddingBottom: 3,
+							   opacity      : 0.99,
+							   marginTop    : "75px",
+							   flexGrow: 1,
+						   }}>
+					{props.pageProps.sections && <PageBreadcrumbs page={props.pageProps}/>}
+					{props.pageProps.notes && <SlideNotes notesArray={props.pageProps.notes}/>}
 
-				<Fade in={transitionDone}
-					  timeout={Theme.transitionDuration.page}>
-					<Box>
-						{props.pageProps.sections && props.pageProps.sections.map((section, index) => {
-							return <PageSectionResponsive key={index} props={section}></PageSectionResponsive>
-						})}
-						{props.children}
-					</Box>
-				</Fade>
-				<FloatingActionButton pageProps={props.pageProps}/>
+					<Fade in={transitionDone}
+						  timeout={Theme.transitionDuration.page}>
+						<Box>
+							{props.pageProps.sections && props.pageProps.sections.map((section, index) => {
+								return <PageSectionResponsive key={index} props={section}></PageSectionResponsive>
+							})}
+							{props.children}
+						</Box>
+					</Fade>
+					<FloatingActionButton pageProps={props.pageProps}/>
+				</Container>
 				<PageFooter />
-			</Container>
+			</Box>
 			<PopupCard/>
 		</Provider>
 	</ThemeProvider>)

--- a/src/components/PageElements/Page.tsx
+++ b/src/components/PageElements/Page.tsx
@@ -1,4 +1,4 @@
-import { Box, Container, Fade, Stack, ThemeProvider, useMediaQuery } from "@mui/material"
+import { Box, Container, Fade, Stack, ThemeProvider, Tooltip, Typography, useMediaQuery } from "@mui/material"
 import ResponsiveTopBar from "../Navigation/TopBar"
 import * as React from "react"
 import { ReactNode, useEffect, useState } from "react"
@@ -14,10 +14,40 @@ import PopupCard from "../UIElement/PopupCard"
 import Theme from "../../config/Theme"
 import { store } from "../../config/Main"
 import { TemplatePageProps } from "../TemplatedDataProps"
+import { formatBuildDate, useSiteMetadata } from "../../Utils"
 
 interface PageProps {
 	pageProps: TemplatePageProps,
 	children?: ReactNode
+}
+
+const PageFooter = () => {
+	const { buildTime, commitSha, version } = useSiteMetadata()
+	const formattedDate = formatBuildDate(buildTime)
+
+	return (
+		<Box
+			component="footer"
+			sx={{
+				textAlign: "center",
+				py: 2,
+				mt: 4,
+				opacity: 0.6,
+			}}
+		>
+			<Tooltip title={`Commit: ${commitSha}`} arrow>
+				<Typography
+					variant="caption"
+					sx={{
+						cursor: "default",
+						"&:hover": { opacity: 0.8 }
+					}}
+				>
+					Last updated {formattedDate} · v{version}
+				</Typography>
+			</Tooltip>
+		</Box>
+	)
 }
 
 const Page = (props: PageProps) => {
@@ -77,6 +107,7 @@ const Page = (props: PageProps) => {
 					</Box>
 				</Fade>
 				<FloatingActionButton pageProps={props.pageProps}/>
+				<PageFooter />
 			</Container>
 			<PopupCard/>
 		</Provider>


### PR DESCRIPTION
<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

📝 **Summary**
- Add last-updated timestamp and version display in the site footer via a new **PageFooter** component showing "Last updated [date]" with commit SHA revealed on hover.
- Inject build metadata (timestamp, commit SHA) from GitHub Actions via environment variables (`GATSBY_BUILD_TIME`, `GATSBY_COMMIT_SHA`), with git-based fallback for local development.

🎯 **Why**
Surface build provenance and freshness to end users; enables readers to understand when content was last deployed. Fixes CI logic to capture the actual PR head commit SHA instead of GitHub's temporary merge-commit SHA.

🔧 **Changes**
- **CI workflows** (`.github/workflows/ci.yml`, `deploy.yml`): Export `GATSBY_BUILD_TIME` and `GATSBY_COMMIT_SHA` env vars to the build step, using PR metadata (`head.sha`, `updated_at`) instead of default merge-commit info.
- **gatsby-config.ts**: Add `getGitInfo()` helper (local git fallback with `child_process.execSync`); expose `buildTime` and `commitSha` in `siteMetadata`, preferring env vars but falling back to git info.
- **Utils.tsx**: Add `formatBuildDate(isoString)` utility (formats ISO dates as "Mon DD, YYYY" in en-US locale) and extend `useSiteMetadata()` hook to query new metadata fields.
- **Page.tsx**: Introduce `PageFooter` component (reads metadata, formats date, renders centered footer with Tooltip wrapping commit SHA); integrate into page layout with flexbox (`minHeight: 100vh`, `flexGrow: 1` on content) to anchor footer to bottom.

🧪 **How to Test**
- **Local**: Verify footer appears at bottom of every page; hover over timestamp to see commit SHA in tooltip; confirm fallback git info displays if env vars are not set.
- **CI**: Check that footer displays correct build timestamp and commit SHA from PR metadata on staging/preview builds; verify correct PR head commit (not merge commit) is displayed.

⚠️ **Risk/Rollout**
Low. UI-only addition with no data or schema changes. Footer opacity set to 0.6 to avoid visual clutter. *Assume* build environment always has `github.event.pull_request.head.sha` and `updated_at` for CI builds; graceful fallback to local git info for development.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->