### PR TITLE
Migrate to single-branch workflow with GitHub Actions Pages deployment

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -2,7 +2,7 @@ name: "PR: Validate & Preview"
 
 on:
   pull_request:
-    branches: ["source"]
+    branches: ["main"]
 
 jobs:
   validate:

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -2,15 +2,22 @@ name: "Deploy: Production"
 
 on:
   push:
-    branches: ["source"]
+    branches: ["main"]
 
-# Allow only one concurrent deployment
+# Sets permissions of the GITHUB_TOKEN to allow deployment to GitHub Pages
+permissions:
+  contents: read
+  pages: write
+  id-token: write
+
+# Allow only one concurrent deployment, skipping runs queued between the run in-progress and latest queued.
+# However, do NOT cancel in-progress runs as we want to allow these production deployments to complete.
 concurrency:
   group: "pages"
-  cancel-in-progress: true
+  cancel-in-progress: false
 
 jobs:
-  build-and-deploy:
+  build:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
@@ -57,9 +64,21 @@ jobs:
           GATSBY_BUILD_TIME: ${{ github.event.head_commit.timestamp }}
           GATSBY_COMMIT_SHA: ${{ github.sha }}
 
-      - name: Deploy to GitHub Pages
-        uses: peaceiris/actions-gh-pages@v4
+      - name: Setup Pages
+        uses: actions/configure-pages@v4
+
+      - name: Upload artifact
+        uses: actions/upload-pages-artifact@v3
         with:
-          github_token: ${{ secrets.GITHUB_TOKEN }}
-          publish_branch: main
-          publish_dir: ./public
+          path: ./public
+
+  deploy:
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
+    runs-on: ubuntu-latest
+    needs: build
+    steps:
+      - name: Deploy to GitHub Pages
+        id: deployment
+        uses: actions/deploy-pages@v4

--- a/README.md
+++ b/README.md
@@ -4,9 +4,7 @@ A personal portfolio built with Gatsby, React, and MaterialUI.
 
 ## Branch Structure
 
-- **Source Branch:** The `source` branch contains the full source code required for building and developing the project. It includes all the necessary files and resources for development.
-
-- **Main Branch:** The `main` branch is used for deployment. It holds the static files generated from the `source` branch and is what gets published on GitHub Pages.
+All development happens on the `main` branch. GitHub Actions automatically builds and deploys to GitHub Pages when changes are pushed.
 
 ## Dependencies
 
@@ -24,11 +22,13 @@ npm run develop
 
 ## Deployment
 
-Deploying to GitHub Pages (`main` branch)
+Deployment is automatic via GitHub Actions when you push to `main`. The workflow:
 
-```
-npm run deploy
-```
+1. Runs type checking
+2. Builds the Gatsby site
+3. Deploys to GitHub Pages using `actions/deploy-pages`
+
+No manual deployment steps are required.
 
 ## Usage Rights
 

--- a/package.json
+++ b/package.json
@@ -13,8 +13,7 @@
 		"build": "gatsby build",
 		"serve": "gatsby serve",
 		"clean": "gatsby clean",
-		"typecheck": "tsc --noEmit",
-		"deploy": "gatsby build && gh-pages -d public -b main"
+		"typecheck": "tsc --noEmit"
 	},
 	"dependencies": {
 		"@emotion/react": "^11.9.3",
@@ -46,7 +45,6 @@
 		"@types/node": "^18.0.3",
 		"@types/react": "^18.0.15",
 		"@types/react-dom": "^18.0.6",
-		"gh-pages": "^4.0.0",
 		"install": "0.13.0",
 		"npm": "^8.13.2",
 		"prettier": "2.7.1",


### PR DESCRIPTION
- Update deploy.yml to use actions/deploy-pages instead of peaceiris/actions-gh-pages
- Change trigger branch from 'source' to 'main' for both deploy and CI workflows
- Add required permissions for GitHub Pages deployment (pages, id-token)
- Update README to reflect single-branch development workflow

This eliminates the need for separate source/main branches. All development now happens on main, and GitHub Actions deploys directly to Pages without pushing built files to a branch.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## 📝 Summary

- Migrate from dual-branch (`source`/`main`) to single-branch (`main`) development workflow by updating CI/CD triggers and removing the source branch requirement
- Replace `peaceiris/actions-gh-pages` with native `actions/deploy-pages@v4` and GitHub Pages environment, eliminating manual deployment scripts and the `gh-pages` npm dependency

## 🎯 Why

Simplifies repository structure and leverages native GitHub Actions Pages support (now generally available), reducing external dependencies and manual deployment steps. All development happens on a single branch; CI/CD pipeline automatically handles type-checking, building, and deployment without pushing built artifacts to a separate branch.

## 🔧 Changes

**Workflows:**
- `ci.yml`: Updated PR trigger to `main` branch (from `source`)
- `deploy.yml`: 
  - Trigger changed to `main` branch
  - Added `permissions` block for GitHub Pages (`pages: write`, `id-token: write`, `contents: read`)
  - Split single `build-and-deploy` job into two sequential jobs: `build` (uploads artifact) → `deploy` (runs `actions/deploy-pages@v4`)
  - Changed `concurrency.cancel-in-progress` from `true` to `false`

**Dependencies & Scripts:**
- Removed `deploy` script from `package.json` (manual deployment no longer needed)
- Removed `gh-pages` from `devDependencies`

**Documentation:**
- Updated README to describe automated three-step workflow (type-check → build → deploy) and single-branch development model; removed manual deployment instructions

## 🧪 How to Test

1. Verify workflow runs on commits/PRs to `main` (not `source`)
2. Confirm GitHub Actions Pages deployment succeeds after build completes
3. Check that the deployed site reflects latest `main` branch changes
4. Validate that no builds or deployments are triggered from `source` branch (should not exist)

## ⚠️ Risk/Rollout

**Breaking change:** Existing `source` branch workflow will no longer trigger deployments. Ensure all team members understand development happens on `main` going forward.

**Deployment risk:** *Assumption* that GitHub Pages environment is properly configured at repository level with appropriate deployment branch/custom domain settings. Verify Pages settings in repository configuration point to "GitHub Actions" as deployment source.

**Mitigation:** If Pages deployment fails, the old `peaceiris/actions-gh-pages` approach can be restored from prior commits. Recommend testing on a staging branch before merging to `main`.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->