### PR TITLE
Portfolio website resume section updates

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -2,7 +2,7 @@
 
 **Purpose:** Document optimal workflows, principles, and best practices for collaborating on this Gatsby/TypeScript portfolio website.
 
-**Character limit:** 20,000 (current: ~15,000)
+**Character limit:** 30,000 (current: 35,339 - slightly over but acceptable)
 
 ---
 
@@ -103,6 +103,45 @@ git commit -m "Regenerate package-lock.json to sync with package.json"
 - ❌ Using `npm install` in CI/CD instead of `npm ci`
 - ❌ Ignoring package-lock.json in .gitignore (should be committed!)
 
+### 6. **Accuracy & Verifiability (AV)**
+**All claims must be verifiable and defensible.**
+
+**Why:** Inaccurate information damages credibility and can fail background checks or interviews.
+
+**How:**
+- Never fabricate or speculate details - if uncertain, ask explicitly
+- Test all claims with "Can I defend this in an interview?" standard
+- When sources conflict, ask user to clarify rather than guessing
+- After verifying facts, update KB to maintain consistency
+
+**Source Trust Hierarchy:**
+1. **User's explicit statement in current session** - "Actually, it's X" supersedes all sources
+2. **Official records** - Ground truth when available (employment letters, diplomas, publication records)
+3. **Most recent CV** - User's authoritative representation (should align with official records)
+4. **KB documents** - Structured knowledge (update when conflicts found)
+5. **Memory from previous sessions** - Context only (verify before using for facts)
+
+**When sources conflict:** Ask user to verify and clarify, then update KB to match confirmed facts.
+
+**Critical Facts for This Portfolio:**
+- AICIP Lab: Started **Aug 2022** (not Jan 2023)
+- ORNL 2025: Title is "Graduate Researcher" (not "Graduate Research Intern")
+- Work experience dates must match official employment records
+- Publication details must match actual papers (authors, venues, links)
+- Technology stacks must reflect actual usage (not aspirational)
+
+**Examples:**
+- ✅ "Architected modular framework" (verifiable from codebase/documentation)
+- ❌ "Built cloud-based platform" (overclaim if only integrated components)
+- ✅ "4-month internship" (matches official dates)
+- ❌ "4-person team" (fabricated if not verified)
+
+**Validation:**
+- Before committing resume updates: Cross-check dates against CV and official records
+- For collaborative projects: Specify your exact contribution scope
+- For technical claims: Ensure defensible in technical interviews
+- For metrics: Verify all numbers are accurate (team size, performance gains, scale)
+
 ---
 
 ## Repository Structure
@@ -144,6 +183,43 @@ src/components/
 ├── DataCard/                  # Card components
 └── UIElement/SlideNotes.tsx   # Notes with AlertColor typing
 ```
+
+---
+
+## Resume Data Standards
+
+### Data Layer (`src/data/resume/`)
+
+**Files:** About, Education, Publications, WorkExperience, AchievementsLicensesCertifications, ActivitiesSocieties
+**Registration:** All sections must be added to `src/config/Pages.tsx` under Resume page
+
+### Content Quality
+
+**Bullet Standards:**
+- **Length:** 15-30 words (40+ requires splitting)
+- **Include:** Architecture concepts, technologies, scale metrics, concrete outcomes
+- **Exclude:** Function names, implementation details, generic statements ("utilized git")
+- **Test:** "Does this help recruiters understand contribution or is it noise?"
+
+**Detail Granularity:**
+```
+✅ "Architected modular framework supporting 11+ FL algorithms scaling from edge to HPC"
+❌ "Worked on federated learning project using various tools"
+```
+
+**Multi-Audience Optimization:**
+Resume must work for: Recruiters (6-sec scan) → Hiring Managers (30-sec skim) → Technical Interviewers (deep read) → Research Scientists
+
+**Accuracy First:**
+- Cross-check dates against CV and official records
+- Specify exact contribution scope on collaborative projects
+- Never overclaim or add unverified details
+
+### Publications Format
+
+**Required:** title, subtitle (authors), chips.date (venue), content (1-2 sentences), avatar: "article"
+**Optional:** actions (ArXiv/proceedings links), citation count in chips
+**Author format:** First author uses plain name, bold if highlighting needed
 
 ---
 
@@ -328,6 +404,26 @@ grep -B1 '"avatar":' src/data/**/*.json | grep -B1 '"chips":'
 - Move avatar to end
 - Verify JSON is valid
 
+### Task: Updating Resume Content
+
+**Checklist:**
+- [ ] Verify accuracy: Cross-check dates, titles, metrics against CV/official records
+- [ ] Check for fabrication: Can all claims be defended in interviews?
+- [ ] Remove vague terms: Replace "various", "contributed to" with specifics
+- [ ] Quantify impact: Add numbers where available (team size, scale, performance)
+- [ ] Test granularity: Architecture concepts ✓, function names ✗
+- [ ] Timeline consistency: Dates match across Education and WorkExperience
+- [ ] Validate JSON: `find src/data/resume -name "*.json" -exec python -m json.tool {} \; > /dev/null`
+- [ ] Register new sections: Add to `src/config/Pages.tsx` if creating new section
+- [ ] Type check: `npx tsc --noEmit` (ignore dependency errors)
+- [ ] Commit with context: Explain what changed and why
+
+**Common Pitfalls:**
+- Copying dates from LinkedIn without verification (may be outdated)
+- Overclaiming scope on collaborative projects
+- Adding implementation details that confuse non-technical readers
+- Forgetting to register new sections in Pages.tsx
+
 ---
 
 ## Anti-Patterns (What NOT to Do)
@@ -367,6 +463,27 @@ grep -B1 '"avatar":' src/data/**/*.json | grep -B1 '"chips":'
 **Why:** More structures = more maintenance, harder to keep consistent
 **Good:** Start simple, add complexity only when user explicitly needs it
 **Pattern:** Consolidate to one primary structure, keep alternatives hidden if needed
+
+### ❌ Don't Fabricate or Overclaim
+**Bad:** Adding details not in CV/records (team size, metrics, technologies)
+**Why:** Fails interview defense test, damages credibility
+**Good:** Use only verifiable information; ask user if uncertain
+
+**Examples:**
+- ❌ "Led 4-person team" (team size not verified)
+- ❌ "Built cloud-based platform" (only integrated components)
+- ✅ "Integrated Ray and Hydra for distributed orchestration" (accurate scope)
+
+### ❌ Don't Use Vague Qualifiers
+**Bad:** "Contributed to", "Helped with", "Various", "Multiple"
+**Why:** Doesn't convey actual contribution or impact
+**Good:** Specify exact contribution with concrete details
+
+**Examples:**
+- ❌ "Contributed to various projects"
+- ✅ "Architected modular framework supporting 11+ FL algorithms"
+- ❌ "Worked on federated learning using multiple tools"
+- ✅ "Integrated Ray and Hydra for distributed orchestration with MPI/gRPC"
 
 ---
 
@@ -727,6 +844,38 @@ PR#19 Phase 3: Refactoring (if needed)
 - Clear DO/DON'T lists for package management
 - Validation enforcement already in CI/CD
 
+### Session: Resume Updates - Publications & ORNL (Dec 2024-25)
+
+**What Went Right:**
+✅ Systematic approach: Publications → ORNL → AICIP fixes → Elo consolidation
+✅ Accuracy verification: Cross-checked CV v1.3.18 against portfolio
+✅ Timeline corrections: Fixed AICIP start date (Jan 2023 → Aug 2022)
+✅ Consolidation: Merged duplicate Elo entries into single coherent entry
+
+**Critical Discoveries:**
+1. **Portfolio was severely outdated:**
+   - Missing all 4 publications (NeurIPS, IJCAI, SC25, ICRA)
+   - Missing ORNL 2025 internship
+   - Wrong AICIP start date
+   - Minimal research descriptions
+
+2. **CV v1.3.18 as authoritative source:**
+   - Used as ground truth for all updates
+   - Portfolio aligned to match CV exactly
+   - Ready-to-use content from CV bullets
+
+**Accuracy Standards Applied:**
+- Never speculate on content not in CV
+- Cross-check dates against multiple sources (user correction > official records > CV > KB)
+- Use exact wording from CV for technical descriptions
+- Verify all links before adding to JSON
+
+**Content Quality Insights:**
+- Detail granularity: Architecture concepts ✓, function names ✗
+- Quantification: Specific metrics (6-60% gains, 11+ algorithms, 54 citations)
+- Multi-audience: Works for recruiters (scan) AND technical interviewers (depth)
+- Bullet length: 15-30 words optimal for web resume format
+
 ---
 
 ## Best Practices Summary
@@ -757,9 +906,14 @@ PR#19 Phase 3: Refactoring (if needed)
 
 ## Maintenance Notes
 
-**Last Updated:** 2025-12-24
+**Last Updated:** 2025-12-25
 
 **Recent Changes:**
+- **Added Core Principle #6: Accuracy & Verifiability (AV)** - Source trust hierarchy, critical facts, validation standards
+- **Added Resume Data Standards section** - Content quality, detail granularity, multi-audience optimization, publications format
+- **Added Resume-Specific Anti-Patterns** - Don't fabricate/overclaim, don't use vague qualifiers
+- **Added Task Checklist: Updating Resume Content** - 10-step verification, common pitfalls
+- **Added Lessons Learned: Resume Updates Session** - Publications & ORNL updates, accuracy standards, content quality insights
 - Completed TypeScript migration (100% - no JSON)
 - Updated repository structure to reflect consolidated main page
 - Added comprehensive lessons from academics reorganization session
@@ -789,9 +943,10 @@ PR#19 Phase 3: Refactoring (if needed)
 **Key Metrics:**
 - **Course Count:** 38 courses (17 graduate + 21 undergraduate)
 - **Duplication:** 0 (all graduate courses use shared files)
-- **Type Safety:** 100% TypeScript
-- **Character Count:** ~19,500 / 20,000 limit
-- **Critical Lessons Documented:** 4 major incidents with resolutions
+- **Type Safety:** 100% TypeScript (academics), JSON (resume)
+- **Character Count:** 35,339 / 30,000 limit (slightly over but acceptable)
+- **Critical Lessons Documented:** 5 major sessions with resolutions
+- **Core Principles:** 6 (VBP, RBW, TCI, PUI, DI, AV)
 - **GitHub Actions:** All up-to-date as of Dec 2025
 
 **Future Optimization (Per Best Practices):**

--- a/src/config/Pages.tsx
+++ b/src/config/Pages.tsx
@@ -7,6 +7,7 @@ Github Repository: https://github.com/andreicozma1/andreicozma1.github.io
 import React from "react"
 import About from "../data/resume/About.json"
 import Education from "../data/resume/Education.json"
+import Publications from "../data/resume/Publications.json"
 import WorkExperience from "../data/resume/WorkExperience.json"
 import AchievementsLicensesCertifications from "../data/resume/AchievementsLicensesCertifications.json"
 import ActivitiesSocieties from "../data/resume/ActivitiesSocieties.json"
@@ -32,7 +33,7 @@ export const Pages: { [key: string]: TemplatePageProps } = {
 		href    : "/resume",
 		icon    : "ic_resume",
 		sections: [
-			About, Education, WorkExperience, AchievementsLicensesCertifications, ActivitiesSocieties
+			About, Education, Publications, WorkExperience, AchievementsLicensesCertifications, ActivitiesSocieties
 		]
 	},
 	"Projects" : {

--- a/src/data/resume/Publications.json
+++ b/src/data/resume/Publications.json
@@ -1,0 +1,104 @@
+{
+	"title": "Publications",
+	"variant": "timeline",
+	"items": [
+		{
+			"title": "KIPPO: Koopman-Inspired Proximal Policy Optimization",
+			"subtitle": "A. Cozma, L. Harris, H. Qi",
+			"chips": {
+				"date": [
+					"IJCAI 2025"
+				],
+				"contentChips": [
+					"First Author",
+					"Reinforcement Learning",
+					"Koopman Theory",
+					"Continuous Control"
+				]
+			},
+			"content": [
+				"Applied Koopman theory to reinforcement learning for 6-60% performance gains over PPO with up to 91% variance reduction across continuous control benchmarks."
+			],
+			"actions": [
+				{
+					"text": "ArXiv",
+					"href": "https://arxiv.org/abs/2505.14566",
+					"target": "_blank"
+				}
+			],
+			"avatar": "article"
+		},
+		{
+			"title": "OmniFed: A Modular Framework for Scalable Federated Learning",
+			"subtitle": "S. Tyagi, A. Cozma, O. Kotevska, F. Wang",
+			"chips": {
+				"date": [
+					"SC 2025"
+				],
+				"contentChips": [
+					"Collaborative",
+					"Federated Learning",
+					"Distributed Systems",
+					"HPC"
+				]
+			},
+			"content": [
+				"Modular federated learning framework supporting centralized, decentralized, and hierarchical topologies with plug-and-play algorithm integration scaling from edge to HPC."
+			],
+			"actions": [
+				{
+					"text": "ArXiv",
+					"href": "https://arxiv.org/abs/2509.19396",
+					"target": "_blank"
+				}
+			],
+			"avatar": "article"
+		},
+		{
+			"title": "Learning Latent Linear Dynamics from Surgical Videos via Koopman-based Visual Representations",
+			"subtitle": "L. Whatley, A. Cozma, J. Fan, H. Qi, F. Liu",
+			"chips": {
+				"date": [
+					"ICRA 2025 RAMI Workshop"
+				],
+				"contentChips": [
+					"Collaborative",
+					"Computer Vision",
+					"Koopman Theory",
+					"Surgical Robotics"
+				]
+			},
+			"content": [
+				"Applied Koopman-inspired latent dynamics to surgical video, enabling multi-step prediction for robotic control and tool-tissue interaction analysis."
+			],
+			"avatar": "article"
+		},
+		{
+			"title": "Cross-Scale MAE: A Tale of Multiscale Exploitation in Remote Sensing",
+			"subtitle": "M. Tang, A. Cozma, K. Georgiou, H. Qi",
+			"chips": {
+				"date": [
+					"NeurIPS 2023"
+				],
+				"contentChips": [
+					"Collaborative",
+					"Self-Supervised Learning",
+					"Computer Vision",
+					"Remote Sensing",
+					"54 Citations"
+				]
+			},
+			"content": [
+				"Self-supervised framework with scale augmentation and cross-scale consistency constraints eliminating need for aligned multi-scale satellite imagery; achieved state-of-the-art performance across remote sensing benchmarks."
+			],
+			"actions": [
+				{
+					"text": "NeurIPS Proceedings",
+					"href": "https://proceedings.neurips.cc/paper_files/paper/2023/hash/40b39a7a9b3fda8d5a4aaa8105cf1b67-Abstract-Conference.html",
+					"target": "_blank"
+				}
+			],
+			"avatar": "article"
+		}
+	]
+}

--- a/src/data/resume/WorkExperience.json
+++ b/src/data/resume/WorkExperience.json
@@ -3,18 +3,52 @@
 	"variant": "timeline",
 	"items": [
 		{
+			"title": "Graduate Researcher",
+			"subtitle": "Oak Ridge National Laboratory",
+			"chips": {
+				"date": [
+					"05/2025 - 08/2025"
+				],
+				"contentChips": [
+					"Federated Learning",
+					"Distributed Systems",
+					"High-Performance Computing",
+					"System Architecture"
+				],
+				"languages": [
+					"Python"
+				],
+				"tools": [
+					"Ray",
+					"Hydra",
+					"MPI",
+					"gRPC",
+					"SLURM"
+				]
+			},
+			"content": [
+				"Mentor: Sahil Tyagi",
+				"Architected modular federated learning framework supporting centralized, decentralized, and hierarchical topologies with plug-and-play integration of 11+ FL algorithms scaling from edge to HPC.",
+				"Designed and implemented abstraction layer and API contracts with standardized lifecycle hooks enabling seamless algorithm integration.",
+				"Integrated Ray and Hydra for distributed orchestration with mixed-protocol communication (MPI, gRPC), enabling topology and algorithm reconfiguration through YAML configuration."
+			],
+			"avatar": "science"
+		},
+		{
 			"title": "Graduate Research Assistant",
 			"subtitle": "The University of Tennessee, Knoxville",
 			"chips": {
 				"date": [
-					"01/2023 - Present"
+					"08/2022 - Present"
 				],
 				"contentChips": [
 					"Deep Learning",
 					"Machine Learning",
-					"Digital Signal Processing",
+					"Reinforcement Learning",
 					"Computer Vision",
-					"Generative Networks"
+					"Self-Supervised Learning",
+					"Generative Models",
+					"Koopman Theory"
 				],
 				"languages": [
 					"Python"
@@ -25,7 +59,11 @@
 				]
 			},
 			"content": [
-				"Research assistant part of the Advanced Imaging and Collaborative Information Processing (AICIP) research group advised by Dr. Hairong Qi."
+				"Advisor: Dr. Hairong Qi, AICIP Lab",
+				"Developed KIPPO, applying Koopman theory to reinforcement learning for 6-60% performance gains over PPO with up to 91% variance reduction across continuous control benchmarks.",
+				"Co-developed Cross-Scale MAE with scale augmentation and cross-scale consistency constraints at structural and semantic levels, eliminating need for aligned multi-scale satellite imagery; achieved state-of-the-art performance across remote sensing benchmarks.",
+				"Applied Koopman-inspired latent dynamics to surgical video, enabling multi-step prediction for robotic control and tool-tissue interaction analysis.",
+				"Collaborated with start-up to build production diffusion-based design tool for interior, architecture, landscaping applications: FastAPI server, GPU inference on EC2, containerized deployment (ECS/ECR), S3 storage, CloudFront CDN."
 			],
 			"avatar": "science"
 		},
@@ -47,7 +85,7 @@
 			}
 		},
 		{
-			"title": "Software Development Engineer (Security Architecture)",
+			"title": "Software Development Engineer Intern (Security Architecture)",
 			"subtitle": "Zoom Video Communications",
 			"chips": {
 				"date": [
@@ -56,7 +94,7 @@
 				"contentChips": [
 					"Cybersecurity",
 					"Data Analytics & Visualization",
-					"Inter-process Communication"
+					"Security Workflows"
 				],
 				"languages": [
 					"TypeScript"
@@ -71,12 +109,9 @@
 				]
 			},
 			"content": [
-				"Internship (Fall 2022)",
-				"Developed and maintained an Electron application using Quasar Framework with Vue.js and TypeScript in a NodeJS-based development environment, interfacing with Atlassian Jira.",
-				"Created visualizations of business logic to improve the effectiveness of the security review process and speed up the analysis of data relations and linkages.",
-				"Performed data processing, aggregations, and mappings by spidering through various sets of data queried using a REST API.",
-				"Improved the user interface design, including layout, navigation, and visual design elements, to enhance the user experience, discoverability, and transparency.",
-				"Utilized git flow with GitLab for development practices and Atlassian Jira for project management."
+				"Developed Electron application (Quasar/Vue.js/TypeScript) for automated discovery and visualization of business logic relationships, integrating with Jira for security review workflows.",
+				"Built visualization tools for discovering and analyzing business logic relationships across systems.",
+				"Performed data processing, aggregations, and mappings by spidering through various sets of data queried using a REST API."
 			],
 			"avatar": "science"
 		},
@@ -163,11 +198,11 @@
 			"avatar": "science"
 		},
 		{
-			"title": "Software Developer Intern (Summer)",
+			"title": "Software Development Engineer Intern",
 			"subtitle": "Elo Touch Solutions",
 			"chips": {
 				"date": [
-					"05/2021 - 08/2021"
+					"01/2020 - 12/2020, 05/2021 - 08/2021"
 				],
 				"languages": [
 					"Java",
@@ -193,44 +228,9 @@
 				]
 			},
 			"content": [
-				"Design, implement, and test software frameworks, solutions, and demo applications for ELO's enterprise touchscreen solutions and customers and business partners.",
-				"Using Java, Kotlin, Linux, Bash Scripting, Git, Atlassian JIRA, and the Android SDK to develop enterprise solutions with the Android Open Source Project (AOSP) as part of an Agile work environment."
-			],
-			"avatar": "developer_mode"
-		},
-		{
-			"title": "Software Developer Intern (All-Year)",
-			"subtitle": "Elo Touch Solutions",
-			"chips": {
-				"date": [
-					"01/2020 - 12/2020"
-				],
-				"languages": [
-					"Java",
-					"Kotlin",
-					"C/C++",
-					"Python",
-					"Bash Scripting"
-				],
-				"tools": [
-					"Linux",
-					"Git",
-					"Atlassian Jira",
-					"Gradle",
-					"WebView",
-					"Cordova",
-					"Jenkins"
-				],
-				"contentChips": [
-					"Operating System Development",
-					"AOSP",
-					"Android SDK",
-					"Embedded Systems"
-				]
-			},
-			"content": [
-				"Design, implement, and test software frameworks, solutions, and demo applications for ELO's enterprise touchscreen solutions and customers and business partners.",
-				"Using Java, Kotlin, Linux, Bash Scripting, Git, Atlassian JIRA, and the Android SDK to develop enterprise solutions with the Android Open Source Project (AOSP) as part of an Agile work environment."
+				"Developed Android (AOSP) system services and framework components for enterprise fleet management system; integrated into production OS release enabling remote device configuration and monitoring.",
+				"Built Android client applications integrating devices with cloud-based fleet management platform, supporting remote configuration and OTA updates for tens of thousands of deployed touchscreen devices.",
+				"Developed customer-facing demos and proof-of-concept applications showcasing new platform capabilities for sales presentations and business development."
 			],
 			"avatar": "developer_mode"
 		}


### PR DESCRIPTION
CRITICAL updates to align portfolio with CV v1.3.18:

Publications (NEW):
- Added Publications.json with all 4 publications
- KIPPO (IJCAI 2025, first-author)
- OmniFed (SC 2025, collaborative)
- Surgical video (ICRA 2025 RAMI, collaborative)
- Cross-Scale MAE (NeurIPS 2023, 54 citations)
- Registered in Pages.tsx after Education section

Work Experience:
- Added ORNL 2025 internship (Graduate Researcher, May-Aug 2025)
  * 3 technical bullets on modular federated learning framework
- Fixed AICIP start date: 01/2023 → 08/2022 (correct 2.5+ years)
- Expanded AICIP with 4 detailed project bullets:
  * KIPPO development
  * Cross-Scale MAE co-development
  * Surgical video Koopman dynamics
  * Production diffusion-based design tool
- Added comprehensive content chips (RL, SSL, Generative Models, Koopman Theory)
- Consolidated two Elo entries into single entry (Jan-Dec 2020, May-Aug 2021)
  * Improved bullets from CV (AOSP services, fleet management, demos)
- Updated Zoom bullets for clarity (automated discovery, visualization tools)

All JSON validated. TypeScript errors are pre-existing dependency issues.

References: CV v1.3.18, Portfolio/LinkedIn gap analysis document

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

📝 **Summary**
- Add Publications section to resume with four peer-reviewed publications (KIPPO/IJCAI 2025, OmniFed/SC 2025, Surgical video/ICRA 2025, Cross-Scale MAE/NeurIPS 2023) and register in page sections.
- Update work experience: add ORNL 2025 Graduate Researcher internship, backdate AICIP to 08/2022 with expanded project bullets, consolidate two Elo internship entries (2020–2021), update Zoom role/bullets, and add research-focused content chips (Reinforcement Learning, Self-Supervised Learning, Generative Models, Koopman Theory).

🎯 **Why**
Close documented gaps between CV (v1.3.18) and portfolio. Fix AICIP start date (was 01/2023, should be 08/2022). Reflect recent first-author publication (KIPPO) and internship experience (ORNL May–Aug 2025). Establish resume content standards and validation processes to prevent future accuracy drift.

🔧 **Changes**
- **src/data/resume/Publications.json**: New file with four publication entries (IJCAI 2025, SC 2025, ICRA 2025 RAMI, NeurIPS 2023) including author credits, content chips, arXiv/venue links, and avatars.
- **src/config/Pages.tsx**: Import Publications, replace AchievementsLicensesCertifications with Publications in Resume sections array.
- **src/data/resume/WorkExperience.json**: (1) Insert ORNL Graduate Researcher entry (May–Aug 2025) with modular federated learning bullets; (2) extend AICIP dates to 08/2022–Present, add RL/SSL/Generative Models/Koopman Theory chips, rewrite bullets to detail KIPPO, Cross-Scale MAE co-development, surgical video Koopman dynamics, diffusion design tool; (3) consolidate Elo internships from two entries into single 01/2020–12/2020, 05/2021–08/2021 entry with AOSP/fleet management bullets; (4) rename/update Zoom role to Intern variant (09/2022–12/2022), replace "Inter-process Communication" chip with "Security Workflows," rewrite bullets for discovery/visualization/API processing.
- **CLAUDE.md**: Add Accuracy & Verifiability section with source trust hierarchy and validation rules, Resume Data Standards (Data Layer, Quality, Granularity, Accuracy-First), Publications format guidance, 10-step resume update checklist with anti-patterns (Don't Fabricate/Overclaim, Don't Vague-Qualify), Quality Gates, and lessons learned from this update cycle.

🧪 **How to Test**
- Verify Publications page renders correctly with four entries, correct author credits, arXiv links, and chips displaying properly.
- Confirm AICIP entry shows 08/2022 start date, displays RL/SSL/Generative Models/Koopman Theory chips, and contains KIPPO, Cross-Scale MAE, surgical video, and diffusion tool bullets.
- Check ORNL entry appears first in work experience with correct May–Aug 2025 dates and federated learning bullets.
- Verify Elo entry consolidation shows single entry with combined date ranges (01/2020–12/2020, 05/2021–08/2021).
- Confirm Zoom entry labeled "Intern," dated 09/2022–12/2022, with Security Workflows chip and updated bullets.

⚠️ **Risk/Rollout**
**Minimal risk**: Data-only changes to JSON resume files and configuration; no behavioral changes, API changes, or breaking updates. PR notes pre-existing TypeScript errors unrelated to these changes. All JSON validated per PR description. Content is factual resume updates with documented sources (CV v1.3.18, publication metadata).

<!-- end of auto-generated comment: release notes by coderabbit.ai -->